### PR TITLE
Add postinstall scripts which throw an error if the os or cpu is different to what the package supports

### DIFF
--- a/sass-linux-ia32/package.json
+++ b/sass-linux-ia32/package.json
@@ -12,5 +12,8 @@
   ],
   "cpu": [
     "ia32"
-  ]
+  ],
+  "scripts": {
+    "postinstall": "node ./postinstall.js"
+  }
 }

--- a/sass-linux-ia32/postinstall.js
+++ b/sass-linux-ia32/postinstall.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const { name, os, cpu } = require("./package.json");
+
+if (os && !os.includes(process.platform)) {
+  throw new Error(
+    `${name} does not support the platform you are using. You are using: "${
+      process.platform
+    }" and ${name} supports: ${os.join(
+      ","
+    )}. If you think this is a mistake, please contact Origami or open an issue on https://github.com/Financial-Times/sass/issues`
+  );
+}
+
+if (cpu && !cpu.includes(process.arch)) {
+  throw new Error(
+    `${name} does not support the cpu you are using. You are using: "${
+      process.arch
+    }" and ${name} supports: ${cpu.join(
+      ","
+    )}. If you think this is a mistake, please contact Origami or open an issue on https://github.com/Financial-Times/sass/issues`
+  );
+}

--- a/sass-linux-x64/package.json
+++ b/sass-linux-x64/package.json
@@ -12,5 +12,8 @@
   ],
   "cpu": [
     "x64"
-  ]
+  ],
+  "scripts": {
+    "postinstall": "node ./postinstall.js"
+  }
 }

--- a/sass-linux-x64/postinstall.js
+++ b/sass-linux-x64/postinstall.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const { name, os, cpu } = require("./package.json");
+
+if (os && !os.includes(process.platform)) {
+  throw new Error(
+    `${name} does not support the platform you are using. You are using: "${
+      process.platform
+    }" and ${name} supports: ${os.join(
+      ","
+    )}. If you think this is a mistake, please contact Origami or open an issue on https://github.com/Financial-Times/sass/issues`
+  );
+}
+
+if (cpu && !cpu.includes(process.arch)) {
+  throw new Error(
+    `${name} does not support the cpu you are using. You are using: "${
+      process.arch
+    }" and ${name} supports: ${cpu.join(
+      ","
+    )}. If you think this is a mistake, please contact Origami or open an issue on https://github.com/Financial-Times/sass/issues`
+  );
+}

--- a/sass-macos-x64/package.json
+++ b/sass-macos-x64/package.json
@@ -9,5 +9,8 @@
   },
   "os": [
     "darwin"
-  ]
+  ],
+  "scripts": {
+    "postinstall": "node ./postinstall.js"
+  }
 }

--- a/sass-macos-x64/postinstall.js
+++ b/sass-macos-x64/postinstall.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const { name, os, cpu } = require("./package.json");
+
+if (os && !os.includes(process.platform)) {
+  throw new Error(
+    `${name} does not support the platform you are using. You are using: "${
+      process.platform
+    }" and ${name} supports: ${os.join(
+      ","
+    )}. If you think this is a mistake, please contact Origami or open an issue on https://github.com/Financial-Times/sass/issues`
+  );
+}
+
+if (cpu && !cpu.includes(process.arch)) {
+  throw new Error(
+    `${name} does not support the cpu you are using. You are using: "${
+      process.arch
+    }" and ${name} supports: ${cpu.join(
+      ","
+    )}. If you think this is a mistake, please contact Origami or open an issue on https://github.com/Financial-Times/sass/issues`
+  );
+}

--- a/sass-windows-ia32/package.json
+++ b/sass-windows-ia32/package.json
@@ -12,5 +12,8 @@
   ],
   "cpu": [
     "ia32"
-  ]
+  ],
+  "scripts": {
+    "postinstall": "node ./postinstall.js"
+  }
 }

--- a/sass-windows-ia32/postinstall.js
+++ b/sass-windows-ia32/postinstall.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const { name, os, cpu } = require("./package.json");
+
+if (os && !os.includes(process.platform)) {
+  throw new Error(
+    `${name} does not support the platform you are using. You are using: "${
+      process.platform
+    }" and ${name} supports: ${os.join(
+      ","
+    )}. If you think this is a mistake, please contact Origami or open an issue on https://github.com/Financial-Times/sass/issues`
+  );
+}
+
+if (cpu && !cpu.includes(process.arch)) {
+  throw new Error(
+    `${name} does not support the cpu you are using. You are using: "${
+      process.arch
+    }" and ${name} supports: ${cpu.join(
+      ","
+    )}. If you think this is a mistake, please contact Origami or open an issue on https://github.com/Financial-Times/sass/issues`
+  );
+}

--- a/sass-windows-x64/package.json
+++ b/sass-windows-x64/package.json
@@ -12,5 +12,8 @@
   ],
   "cpu": [
     "x64"
-  ]
+  ],
+  "scripts": {
+    "postinstall": "node ./postinstall.js"
+  }
 }

--- a/sass-windows-x64/postinstall.js
+++ b/sass-windows-x64/postinstall.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const { name, os, cpu } = require("./package.json");
+
+if (os && !os.includes(process.platform)) {
+  throw new Error(
+    `${name} does not support the platform you are using. You are using: "${
+      process.platform
+    }" and ${name} supports: ${os.join(
+      ","
+    )}. If you think this is a mistake, please contact Origami or open an issue on https://github.com/Financial-Times/sass/issues`
+  );
+}
+
+if (cpu && !cpu.includes(process.arch)) {
+  throw new Error(
+    `${name} does not support the cpu you are using. You are using: "${
+      process.arch
+    }" and ${name} supports: ${cpu.join(
+      ","
+    )}. If you think this is a mistake, please contact Origami or open an issue on https://github.com/Financial-Times/sass/issues`
+  );
+}


### PR DESCRIPTION


This is a required for npm ci to work. https://github.com/npm/cli/issues/558