### PR TITLE
Add ability to publish prereleases with a different dist-tag

### DIFF
--- a/.github/workflows/automatic-tag-and-release.yml
+++ b/.github/workflows/automatic-tag-and-release.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }} # Checkout the merged commit
           fetch-depth: 0
+          token: ${{ secrets.ORIGAMI_VERSION_TOKEN }}
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* # Get all tags from the origin
         if: github.event.pull_request.merged # Only run on merged pull-requests
       - uses: Financial-Times/origami-version@v1.2.0

--- a/.github/workflows/publish-to-npm-as-latest.yml
+++ b/.github/workflows/publish-to-npm-as-latest.yml
@@ -1,0 +1,39 @@
+name: Publish to npm as latest version
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+' # non-prerelease tag
+jobs:
+  publish-latest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2.1.2
+      with:
+        node-version: '12.x'
+        registry-url: 'https://registry.npmjs.org'
+    - name: package sub-packages for npm
+      shell: bash
+      run: |
+        for pkg in `ls -1d ./*/`;
+        do
+          cd $pkg;
+          ref='${{github.ref}}'
+          npm version --no-git-tag-version ${ref#refs/tags/}
+          npm publish --access=public;
+          cd -;
+        done
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: Publish meta-package to npm
+      shell: bash
+      run: |
+        ref='${{github.ref}}'
+        for pkg in `/bin/ls -1d sass-*`;
+        do
+          npm install -f --ignore-scripts --save-optional "@financial-times/$pkg@*";
+        done
+        npm version -f --no-git-tag-version ${ref#refs/tags/}
+        npm publish --access=public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-to-npm-as-prerelease.yml
+++ b/.github/workflows/publish-to-npm-as-prerelease.yml
@@ -1,14 +1,14 @@
-name: Publish to npm
+name: Publish to npm as prerelease version
 on:
-  release:
-    types: [created]
-
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+-*' # prerelease tag
 jobs:
-  release:
+  publish-prerelease:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2.1.4
+    - uses: actions/setup-node@v2.1.2
       with:
         node-version: '12.x'
         registry-url: 'https://registry.npmjs.org'
@@ -20,7 +20,7 @@ jobs:
           cd $pkg;
           ref='${{github.ref}}'
           npm version --no-git-tag-version ${ref#refs/tags/}
-          npm publish --access=public;
+          npm publish --access=public --tag prerelease
           cd -;
         done
       env:
@@ -34,6 +34,6 @@ jobs:
           npm install -f --ignore-scripts --save-optional "@financial-times/$pkg@*";
         done
         npm version -f --no-git-tag-version ${ref#refs/tags/}
-        npm publish --access=public
+        npm publish --access=public --tag prerelease
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Prior to this change, every release would be given the dist-tag `latest`, which is not what we want. We only want stable releases to be given the `latest` dist-tag